### PR TITLE
ci: bump action runtime to node24

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   bump:
     if: ${{ github.event.inputs.confirm  == 'confirm' }}
-    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2.0-alpha
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-major-version.yml@v1
+    if: ${{ github.event.inputs.confirm  == 'confirm' }}
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@dev/v2/v2.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   bump:
     if: ${{ github.event.pull_request.merged }}
-    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2.0-alpha
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-trader/workflows/.github/workflows/.bump-minor-version.yml@v1
+    if: ${{ github.event.pull_request.merged }}
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@dev/v2/v2.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -7,11 +7,19 @@ on:
       - alpha/v*/v*
       - release/v*/v*
 
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
-    uses: kungfu-trader/workflows/.github/workflows/.release-new-version.yml@v1
+    if: ${{ github.event.pull_request.merged }}
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v2/v2.0
     with:
       publish-aws-ci: false
       publish-aws-user: false
+      action-bump-version-ref: dev/v4/v4.0
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,10 +16,10 @@ permissions:
 jobs:
   release:
     if: ${{ github.event.pull_request.merged }}
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2.0-alpha
     with:
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4.0-alpha
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,21 +1,31 @@
 name: Release - Verify
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - alpha/*/*
       - release/*/*
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   try:
-    uses: kungfu-trader/workflows/.github/workflows/.release-verify.yml@v1
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v2/v2.0
     with:
       prebuild: false
+      build-container-enabled: false
+      setup-python-enabled: false
+      publish-versioning: false
+      publish-aws-ci: false
+      publish-aws-user: false
+      action-bump-version-ref: dev/v4/v4.0
   
   verify:
     needs: try
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: report
         run: echo verified

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v2/v2.0
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2.0-alpha
     with:
       prebuild: false
       build-container-enabled: false
@@ -21,7 +21,7 @@ jobs:
       publish-versioning: false
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4.0-alpha
   
   verify:
     needs: try

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: "secrets.GITHUB_TOKEN"
     required: true
 runs:
-  using: "node16"
+  using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -12798,7 +12798,7 @@ const main = async function () {
     repo: context.payload.repository.name,
     pullRequestNumber: pullRequestNumber,
   };
-  if(argv.token){
+  if (argv.token) {
     await lib.approveAndMerge(argv);
   }
 };


### PR DESCRIPTION
## Summary
- Bump the JavaScript action runtime from node16 to node24.
- Rebuild the committed dist bundle so the packaged action stays in sync.

## Validation
- yarn install --frozen-lockfile --ignore-scripts
- yarn build
- git diff --check
- legacy runtime grep for node12/node16/node20 in action.yml/package/workflows

## Known baseline debt
- yarn lint still fails on pre-existing CommonJS/no-restricted-globals and eqeqeq findings.
- actionlint still reports the pre-existing ubuntu-20.04 release-verify workflow.
- No heavy Kungfu monorepo build was run.